### PR TITLE
feat: move button from display back to input

### DIFF
--- a/cdk/components/display/index.ts
+++ b/cdk/components/display/index.ts
@@ -1,4 +1,3 @@
-import { button } from './button.js'
 import { code } from './code.js'
 import { grid } from './grid.js'
 import { heading } from './heading.js'
@@ -10,7 +9,6 @@ import { text } from './text.js'
 import { video } from './video.js'
 
 export const Display = {
-	button,
 	code,
 	grid,
 	heading,

--- a/cdk/components/input/button.ts
+++ b/cdk/components/input/button.ts
@@ -28,7 +28,7 @@ export const button = (
 			: { action: undefined, iamStatements: [] }
 
 	return new Component({
-		typeName: 'display.button',
+		typeName: 'input.button',
 		props: {
 			...props,
 			onClick: onClick.action,

--- a/cdk/components/input/index.ts
+++ b/cdk/components/input/index.ts
@@ -1,9 +1,11 @@
+import { button } from './button.js'
 import { chat } from './chat.js'
 import { select } from './select.js'
 import { text } from './text.js'
 import { toggle } from './toggle.js'
 
 export const Input = {
+	button,
 	chat,
 	text,
 	toggle,


### PR DESCRIPTION
## I have created this PR because

According to our research it makes more sense for `Button` to be `Input` rather than `Display`.