### PR TITLE
Warn developers that their CDK stack has not been deployed

### DIFF
--- a/cli/lib/appWatcher.ts
+++ b/cli/lib/appWatcher.ts
@@ -255,8 +255,8 @@ export const extractAppsFromStacks = async (
 ): Promise<Apps> => {
 	const acc: Apps = {}
 
-	for (const [stackId, stackData] of Object.entries(stacks)) {
-		acc[stackId] = {}
+	for (const [stackLogicalId, stackData] of Object.entries(stacks)) {
+		acc[stackLogicalId] = {}
 
 		const key = `${stackData.metadata.stackName}__${stackData.metadata.env}`
 		const deployedStackData =
@@ -309,7 +309,8 @@ export const extractAppsFromStacks = async (
 					Properties.AppId[0] === rawAppId
 			)
 
-			acc[stackId][rawAppId] = {
+			acc[stackLogicalId][rawAppId] = {
+				isDeployed: deployedStackData.stackId !== null,
 				executionRoleArn: rawAppTemplate.Properties.ExecutionRoleArn,
 				executionRoleExternalId:
 					typeof rawAppTemplate.Properties.ExecutionRoleExternalId === 'string'

--- a/cli/lib/appWatcher.ts
+++ b/cli/lib/appWatcher.ts
@@ -118,7 +118,7 @@ export const tryToFetchDeployedStack = async (
 
 		for await (const stacks of paginate(
 			async (next) =>
-				stackId !== null
+				stackId === null
 					? cfn
 							.describeStacks({
 								StackName: stack.metadata.stackName,

--- a/cli/lib/types.ts
+++ b/cli/lib/types.ts
@@ -1,8 +1,9 @@
 import { ISerializedComponent } from '@/cdk/utils/Component.js'
 
 export type Apps = {
-	[stackId: string]: {
+	[stackLogicalId: string]: {
 		[appId: string]: {
+			isDeployed: boolean
 			executionRoleArn?: string
 			executionRoleExternalId?: string
 			name: string
@@ -30,7 +31,7 @@ export type CdkForkedStack = {
 }
 
 export type CdkForkedStacks = {
-	[key: string]: CdkForkedStack
+	[logicalId: string]: CdkForkedStack
 }
 
 export type CdkForkedErrors = string[]

--- a/cli/ui/dev.tsx
+++ b/cli/ui/dev.tsx
@@ -46,6 +46,8 @@ export const Dev: React.FC<DevProps> = ({
 
 	const [apiConnections, setApiConnections] = useState<number>(0)
 
+	const [needsDeploy, setNeedsDeploy] = useState<boolean>(false)
+
 	const { exit } = useApp()
 
 	useInput((input, key) => {
@@ -91,6 +93,17 @@ export const Dev: React.FC<DevProps> = ({
 				case 'done':
 					setCurrentPhase('built')
 
+					const allStacksDeployed = Object.entries(event.apps).reduce(
+						(acc, [, apps]) =>
+							Object.entries(apps).reduce(
+								(acc2, [, { isDeployed }]) => acc2 && isDeployed,
+								acc
+							),
+						true
+					)
+
+					setNeedsDeploy(!allStacksDeployed)
+
 					if (event.errors.length > 0) {
 						setErrors((currentErrors) => {
 							let errs =
@@ -132,7 +145,43 @@ export const Dev: React.FC<DevProps> = ({
 
 	return (
 		<Box flexWrap="wrap">
-			<Box width="100%">
+			{needsDeploy ? (
+				<Box width="100%">
+					<Box
+						borderStyle="doubleSingle"
+						borderColor="yellow"
+						flexWrap="wrap"
+						paddingTop={1}
+						paddingRight={2}
+						paddingBottom={1}
+						paddingLeft={2}
+					>
+						<Box width="100%">
+							<Text>
+								{symbols.warning} One of your CDK stacks is not deployed. Some
+								features are limited.
+								<Newline />
+								<Newline />
+								<Text>Run:</Text>
+								<Newline />
+								<Newline />
+								<Text>
+									$ npx cdk deploy
+									{process.env.AWS_PROFILE
+										? ` --profile=${process.env.AWS_PROFILE}`
+										: ''}
+								</Text>
+								<Newline />
+								<Newline />
+								<Text>
+									After you deploy the stack press &quot;Enter&quot; to rebuild.
+								</Text>
+							</Text>
+						</Box>
+					</Box>
+				</Box>
+			) : null}
+			<Box width="100%" paddingTop={1}>
 				{typeof errors !== 'undefined' && errors.length > 0 ? (
 					<Text>
 						<Text>{symbols.error} Error occurred</Text>
@@ -169,7 +218,7 @@ export const Dev: React.FC<DevProps> = ({
 				<Text dimColor>
 					<Text>Press &quot;q&quot; to quit</Text>
 					<Newline />
-					<Text>Press &quot;enter&quot; to rebuild</Text>
+					<Text>Press &quot;Enter&quot; to rebuild</Text>
 				</Text>
 			</Box>
 		</Box>


### PR DESCRIPTION
## I have created this PR because

Buttonize doesn't yet support deploying the CDK stacks for the developers.

For now we can notify the developer about the fact that some features might be limited.

## CLI
![image](https://github.com/buttonize/buttonize/assets/6282843/b4fed12a-8794-4946-9193-0198750d35bb)

## Buttonize

<kbd>

![screely-1711201158703](https://github.com/buttonize/buttonize/assets/6282843/d94c7c0d-39d7-4d95-8682-292e8ac8b9de)

</kbd>
